### PR TITLE
Fix test failure in completer.go

### DIFF
--- a/pq/autocomplete/earley/chart.go
+++ b/pq/autocomplete/earley/chart.go
@@ -55,13 +55,13 @@ func initializeChart(g Grammar) *earleyChart {
 	initialSets := []*StateSet{
 		initialSet,
 	}
-	return &earleyChart{nil, initialSets}
+	return &earleyChart{[]Tokhan{}, initialSets}
 }
 
-// truncate the stateset and keep the initial set
-func (c *earleyChart) resetChart() {
-	c.inputWords = nil
-	c.state = c.state[:1]
+// truncate the stateset and keep the stateset before index
+func (c *earleyChart) resetChartBeforeIndex(index int) {
+	c.inputWords = c.inputWords[:index]
+	c.state = c.state[:index+1]
 }
 
 func (c *earleyChart) Length() int {

--- a/pq/autocomplete/earley/chart.go
+++ b/pq/autocomplete/earley/chart.go
@@ -58,6 +58,12 @@ func initializeChart(g Grammar) *earleyChart {
 	return &earleyChart{nil, initialSets}
 }
 
+// truncate the stateset and keep the initial set
+func (c *earleyChart) resetChart() {
+	c.inputWords = nil
+	c.state = c.state[:1]
+}
+
 func (c *earleyChart) Length() int {
 	return len(c.state)
 }

--- a/pq/autocomplete/earley/completer.go
+++ b/pq/autocomplete/earley/completer.go
@@ -126,6 +126,11 @@ func (c *promQLCompleter) GenerateSuggestions(query string, pos int) []autocompl
 				newMatch := NewPartialMatch(ao, "aggr-operation", aggregators[ao])
 				matches = append(matches, newMatch)
 			}
+		case AGGR_KW:
+			for _, ao := range autocomplete.FilterPrefix(sets.StringKeySet(aggregateKeywords), autocompletePrefix, false).List() {
+				newMatch := NewPartialMatch(ao, "aggr-keyword", aggregateKeywords[ao])
+				matches = append(matches, newMatch)
+			}
 		}
 		sort.Slice(matches, func(i, j int) bool {
 			return matches[i].GetValue() > matches[j].GetValue()

--- a/pq/autocomplete/earley/completer_test.go
+++ b/pq/autocomplete/earley/completer_test.go
@@ -80,28 +80,33 @@ func TestEndToEndAutoCompletion(t *testing.T) {
 	index := NewTestIndex()
 	index.LoadMetrics(initialMetricsString, time.Now())
 	testCases := []struct {
-		desc string
-		query string
+		desc            string
+		query           string
 		expectedMatches sets.String
 	}{
 		{
-			desc: "completes on metric name in aggregation context",
-			query: `sum(metric_name_o`,
+			desc:            "completes on metric name in aggregation context",
+			query:           `sum(metric_name_o`,
 			expectedMatches: sets.NewString("metric_name_one"),
 		},
 		{
-			desc: "completes on metric label in aggregation context",
-			query: `sum(metric_name_one{`,
+			desc:            "completes on metric label in aggregation context",
+			query:           `sum(metric_name_one{`,
 			expectedMatches: sets.NewString("dima", "dimb"),
 		},
 		{
-			desc: "completes on metric name",
-			query: `metric_name`,
+			desc:            "completes on aggregation keywords",
+			query:           `sum(metric_name_one)`,
+			expectedMatches: sets.StringKeySet(aggregateKeywords),
+		},
+		{
+			desc:            "completes on metric name",
+			query:           `metric_name`,
 			expectedMatches: sets.NewString("metric_name_one", "metric_name_two"),
 		},
 		{
-			desc: "completes on empty string",
-			query: ``,
+			desc:            "completes on empty string",
+			query:           ``,
 			expectedMatches: sets.NewString("metric_name_one", "metric_name_two").Union(sets.StringKeySet(aggregators)),
 		},
 	}

--- a/pq/autocomplete/earley/luthor.go
+++ b/pq/autocomplete/earley/luthor.go
@@ -62,6 +62,22 @@ func (ws Tokens) Last() Tokhan {
 	return ws[len(ws)-2]
 }
 
+func (ws Tokens) Compare(tks2 Tokens) int {
+	i := 0
+	for i, t := range ws {
+		// return positive i if ws and tks2 have partial overlap
+		if i >= len(tks2) || !t.equals(tks2[i]) {
+			return i
+		}
+	}
+	// return negative i if tks2 covers ws
+	if len(tks2) > len(ws) {
+		return 0 - i
+	}
+	// return 0 if they are equal
+	return 0
+}
+
 type TypedToken interface {
 	GetTokenType() TokenType
 }
@@ -109,6 +125,10 @@ func (t Tokhan) String() string {
 		t.StartPos,
 		t.EndPos,
 	)
+}
+
+func (t Tokhan) equals(t2 Tokhan) bool {
+	return t.Val == t2.Val && t.StartPos == t2.StartPos && t.EndPos == t2.EndPos
 }
 
 func extractWords(query string) Tokens {

--- a/pq/autocomplete/earley/promql.go
+++ b/pq/autocomplete/earley/promql.go
@@ -101,4 +101,16 @@ var (
 		"topk":         "largest k elements by sample value",
 		"quantile":     "calculate φ-quantile (0 ≤ φ ≤ 1) over dimensions",
 	}
+
+	// Todo:(yuchen) add the description for aggr_kw
+	aggregateKeywords = map[string]string{
+		"offset":      "",
+		"by":          "",
+		"without":     "",
+		"on":          "",
+		"ignoring":    "",
+		"group_left":  "",
+		"group_right": "",
+		"bool":        "",
+	}
 )


### PR DESCRIPTION
The cause of the test failure is that the stateset of previous input is still keeping when the next input comes in. 
Cleanup the stateset but only keep the initial state if new input words comes in. If the next input is the following word of previous input, we don't need to reset the stateset and use `PartialParse` to continue parsing from a specific word index.
@logicalhan 