### PR TITLE
Disable flaky prompt test for now

### DIFF
--- a/promq/term/prompt_test.go
+++ b/promq/term/prompt_test.go
@@ -277,6 +277,8 @@ var _ = Describe("The Prompt widget", func() {
 		})
 
 		It("should never render outside its box", func() {
+			Skip("this has a weird race that's making it flaky -- see note below")
+
 			prompt.HandleInput = func(_ string) (*string, bool) {
 				// never exit normally, just use the cancel in aftereach
 				return nil, false


### PR DESCRIPTION
This disables a flaky prompt test for the moment, until we can fix it.
