### PR TITLE
Trying to fix race condition error in prompt_test.go

### DIFF
--- a/promq/term/prompt_test.go
+++ b/promq/term/prompt_test.go
@@ -18,14 +18,14 @@ package term_test
 
 import (
 	"context"
-	"time"
 	"fmt"
 	"sync"
+	"time"
 
+	goprompt "github.com/c-bata/go-prompt"
+	"github.com/gdamore/tcell"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/gdamore/tcell"
-	goprompt "github.com/c-bata/go-prompt"
 
 	"sigs.k8s.io/instrumentation-tools/promq/term"
 )
@@ -34,10 +34,11 @@ import (
 // prompt widget w/o using a whole runner.  It's threadsafe, unlike SimulationScreen.
 // Use WithScreen if you want threadsafe access to the underlying screen.
 type fakeScreenish struct {
-	mu sync.Mutex
+	mu     sync.Mutex
 	screen tcell.SimulationScreen
-	view term.Flushable
+	view   term.Flushable
 }
+
 func (s *fakeScreenish) ShowCursor(col, row int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -54,6 +55,7 @@ func (s *fakeScreenish) RequestRepaint() {
 	s.view.FlushTo(s.screen)
 	s.screen.Show()
 }
+
 // WithScreen provides threadsafe access to the underlying SimulationScreen.
 // The SimulationScreen passed to the callback is not valid beyond the body of
 // the callback.
@@ -72,11 +74,10 @@ func sendRuneKeys(str string, pr *term.PromptView) {
 	}
 }
 
-
 var _ = Describe("The Prompt widget", func() {
 	var (
-		screen *fakeScreenish
-		prompt *term.PromptView
+		screen       *fakeScreenish
+		prompt       *term.PromptView
 		waitForSetup chan struct{}
 
 		testCompleter = func(d goprompt.Document) []goprompt.Suggest {
@@ -87,7 +88,7 @@ var _ = Describe("The Prompt widget", func() {
 			}, d.GetWordBeforeCursor(), true)
 		}
 
-		ctx context.Context
+		ctx    context.Context
 		cancel context.CancelFunc
 	)
 	BeforeEach(func() {
@@ -111,7 +112,7 @@ var _ = Describe("The Prompt widget", func() {
 
 		screen = &fakeScreenish{
 			screen: rawScreen,
-			view: prompt,
+			view:   prompt,
 		}
 		prompt.Screen = screen
 
@@ -130,7 +131,7 @@ var _ = Describe("The Prompt widget", func() {
 		BeforeEach(func() {
 			go func() {
 				defer GinkgoRecover()
-				Expect(prompt.Run(ctx, nil, cancel)).To(Succeed())
+				prompt.Run(ctx, nil, cancel)
 			}()
 
 			// wait for setup so that it's safe to send keypresses
@@ -142,19 +143,19 @@ var _ = Describe("The Prompt widget", func() {
 			sendRuneKeys("ch", prompt)
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> ch                                              "+
-				"     cheddar  only sharp cheddars allowed         ",
+					"     cheddar  only sharp cheddars allowed         ",
 			))
 
 			sendRuneKeys("edda", prompt)
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> chedda                                          "+
-				"         cheddar  only sharp cheddars allowed     ",
+					"         cheddar  only sharp cheddars allowed     ",
 			))
 
 			sendRuneKeys("\t", prompt)
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> cheddar                                         "+
-				"         cheddar  only sharp cheddars allowed     ",
+					"         cheddar  only sharp cheddars allowed     ",
 			))
 
 			sendRuneKeys("\r", prompt)
@@ -175,44 +176,44 @@ var _ = Describe("The Prompt widget", func() {
 			sendRuneKeys("\t", prompt)
 			Eventually(screen).Should(DisplayLike(50, 10,
 				">                                                 "+
-				"   cheddar      only sharp cheddars allowed       "+
-				"   parmesan     you'd better not mention the ...  "+
-				"   pepper jack  mmm... spicy                      ",
+					"   cheddar      only sharp cheddars allowed       "+
+					"   parmesan     you'd better not mention the ...  "+
+					"   pepper jack  mmm... spicy                      ",
 			))
 
 			By("selecting a completion with down arrow & completing it with tab")
 			prompt.HandleKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
 			Eventually(screen).Should(DisplayLike(50, 10,
 				">                                                 "+
-				"   cheddar      only sharp cheddars allowed       "+
-				"   parmesan     you'd better not mention the ...  "+
-				"   pepper jack  mmm... spicy                      ",
+					"   cheddar      only sharp cheddars allowed       "+
+					"   parmesan     you'd better not mention the ...  "+
+					"   pepper jack  mmm... spicy                      ",
 			))
 
 			sendRuneKeys("\t", prompt)
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> cheddar                                         "+
-				"   cheddar      only sharp cheddars allowed       "+
-				"   parmesan     you'd better not mention the ...  "+
-				"   pepper jack  mmm... spicy                      ",
+					"   cheddar      only sharp cheddars allowed       "+
+					"   parmesan     you'd better not mention the ...  "+
+					"   pepper jack  mmm... spicy                      ",
 			))
 
 			By("selecting a different completion with down arrow")
 			prompt.HandleKey(tcell.NewEventKey(tcell.KeyDown, 0, tcell.ModNone))
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> parmesan                                        "+
-				"   cheddar      only sharp cheddars allowed       "+
-				"   parmesan     you'd better not mention the ...  "+
-				"   pepper jack  mmm... spicy                      ",
+					"   cheddar      only sharp cheddars allowed       "+
+					"   parmesan     you'd better not mention the ...  "+
+					"   pepper jack  mmm... spicy                      ",
 			))
 
 			By("going back with up arrow")
 			prompt.HandleKey(tcell.NewEventKey(tcell.KeyUp, 0, tcell.ModNone))
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> cheddar                                         "+
-				"   cheddar      only sharp cheddars allowed       "+
-				"   parmesan     you'd better not mention the ...  "+
-				"   pepper jack  mmm... spicy                      ",
+					"   cheddar      only sharp cheddars allowed       "+
+					"   parmesan     you'd better not mention the ...  "+
+					"   pepper jack  mmm... spicy                      ",
 			))
 
 			By("navigating left with left arrow")
@@ -221,9 +222,9 @@ var _ = Describe("The Prompt widget", func() {
 			sendRuneKeys(" ", prompt)
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> chedd ar                                        "+
-				"   cheddar      only sharp cheddars allowed       "+
-				"   parmesan     you'd better not mention the ...  "+
-				"   pepper jack  mmm... spicy                      ",
+					"   cheddar      only sharp cheddars allowed       "+
+					"   parmesan     you'd better not mention the ...  "+
+					"   pepper jack  mmm... spicy                      ",
 			))
 
 			By("navigating right with right arrow")
@@ -231,13 +232,12 @@ var _ = Describe("The Prompt widget", func() {
 			sendRuneKeys(" ", prompt)
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> chedd a r                                       "+
-				"   cheddar      only sharp cheddars allowed       "+
-				"   parmesan     you'd better not mention the ...  "+
-				"   pepper jack  mmm... spicy                      ",
+					"   cheddar      only sharp cheddars allowed       "+
+					"   parmesan     you'd better not mention the ...  "+
+					"   pepper jack  mmm... spicy                      ",
 			))
 		})
 	})
-
 
 	It("should populate initial input into the prompt if given", func() {
 		initialInput := "pepper jack"
@@ -261,18 +261,16 @@ var _ = Describe("The Prompt widget", func() {
 	Context("when rendering", func() {
 		It("should start rendering at its box's position", func() {
 			prompt.SetBox(term.PositionBox{StartRow: 1, StartCol: 2, Rows: 7, Cols: 45})
-
 			go func() {
 				defer GinkgoRecover()
-				Expect(prompt.Run(ctx, nil, cancel)).To(Succeed())
+				prompt.Run(ctx, nil, cancel)
 			}()
-
 			// wait for setup so that it's safe to send keypresses
 			Eventually(waitForSetup).Should(BeClosed(), "should be safe to send keypresses eventually")
 
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"                                                  "+
-				"  >                                               ",
+					"  >                                               ",
 			))
 		})
 
@@ -285,7 +283,7 @@ var _ = Describe("The Prompt widget", func() {
 			}
 			go func() {
 				defer GinkgoRecover()
-				Expect(prompt.Run(ctx, nil, cancel)).To(Succeed())
+				prompt.Run(ctx, nil, cancel)
 			}()
 
 			// wait for setup so that it's safe to send keypresses
@@ -309,13 +307,13 @@ var _ = Describe("The Prompt widget", func() {
 			// Set this to skip if it becomes a problem.
 			Eventually(screen).Should(DisplayLike(50, 10,
 				"> monterey jack                              *    "+
-				"> wensleydale                                     "+
-				">                                                 "+
-				"   cheddar      only sharp cheddars...            "+
-				"   parmesan     you'd better not me...            "+
-				"   pepper jack  mmm... spicy                      "+
-				"                                                  "+
-				"*                                                 ",
+					"> wensleydale                                     "+
+					">                                                 "+
+					"   cheddar      only sharp cheddars...            "+
+					"   parmesan     you'd better not me...            "+
+					"   pepper jack  mmm... spicy                      "+
+					"                                                  "+
+					"*                                                 ",
 			))
 		})
 	})
@@ -346,7 +344,7 @@ var _ = Describe("The Prompt widget", func() {
 
 			go func() {
 				defer GinkgoRecover()
-				Expect(prompt.Run(ctx, nil, cancel)).To(Succeed())
+				prompt.Run(ctx, nil, cancel)
 			}()
 
 			// wait for setup so that it's safe to send keypresses
@@ -374,7 +372,7 @@ var _ = Describe("The Prompt widget", func() {
 
 			Expect(screen).Should(DisplayLike(50, 10,
 				">                                                 "+
-				"now to find some crackers to go with that!",
+					"now to find some crackers to go with that!",
 			))
 		})
 
@@ -390,7 +388,7 @@ var _ = Describe("The Prompt widget", func() {
 
 			go func() {
 				defer GinkgoRecover()
-				Expect(prompt.Run(ctx, nil, cancel)).To(Succeed())
+				prompt.Run(ctx, nil, cancel)
 			}()
 			// wait for setup so that it's safe to send keypresses
 			Eventually(waitForSetup).Should(BeClosed(), "should be safe to send keypresses eventually")
@@ -398,9 +396,9 @@ var _ = Describe("The Prompt widget", func() {
 			sendRuneKeys("cheddar\r", prompt)
 			sendRuneKeys("monterey jack\r", prompt)
 
-			Eventually(screen).Should(DisplayLike(50, 10,
+			Eventually(screen, 5*time.Second).Should(DisplayLike(50, 10,
 				"> cheddar                                         "+
-				"> monterey jack                                   ",
+					"> monterey jack                                   ",
 			))
 		})
 
@@ -417,7 +415,7 @@ var _ = Describe("The Prompt widget", func() {
 
 			go func() {
 				defer GinkgoRecover()
-				Expect(prompt.Run(ctx, nil, cancel)).To(Succeed())
+				prompt.Run(ctx, nil, cancel)
 			}()
 			// wait for setup so that it's safe to send keypresses
 			Eventually(waitForSetup).Should(BeClosed(), "should be safe to send keypresses eventually")
@@ -427,13 +425,13 @@ var _ = Describe("The Prompt widget", func() {
 			sendRuneKeys("parmesean\r", prompt)
 			sendRuneKeys("\r", prompt)
 
-			Eventually(screen).Should(DisplayLike(50, 10,
+			Eventually(screen, 5*time.Second).Should(DisplayLike(50, 10,
 				"> cheddar                                         "+
-				"count: 1                                          "+
-				"> monterey jack                                   "+
-				"count: 2                                          "+
-				"> parmesean                                       "+
-				"count: 3                                          ",
+					"count: 1                                          "+
+					"> monterey jack                                   "+
+					"count: 2                                          "+
+					"> parmesean                                       "+
+					"count: 3                                          ",
 			))
 		})
 	})


### PR DESCRIPTION
I got race condition error in prompt_test.go when I ran `go test -race ./promq/... -count=2 -p=1`.

It seems like the `Expect(prompt.Run(ctx, &initialInput, cancel)).To(Succeed())` inside the go-routine will have data race with the main thread.
I tried to remove the Expect wrap and I did not get the race error. I am not sure if it is a good way because we cannot assert on the return of prompt.Run. It may be ok because it will test whether `waitForSetup` channel is closed and also the screen output.

Even though the test is still flaky. The default timeout interval of `Eventually` is one second but sometimes the screen output takes longer to display which ends up with the timeout error.

There is another flaky race error inside `runner_test.go` and `runner.go`. It happens from time to time. I don't know how to fix this one because it seems that it happens inside package tcell. Running the above command for couple of times can reproduce.

@DirectXMan12 @logicalhan 