### PR TITLE
Fix last few test flakes/panics

### DIFF
--- a/promq/prom/parse.go
+++ b/promq/prom/parse.go
@@ -63,6 +63,9 @@ func ParseTextDataWithAdditionalLabels(data []byte, nowish time.Time, ls map[str
 			} else {
 				timestamp = nowAbouts
 			}
+
+			// TODO(directxman12): seems like this is a rather big allocation, would
+			// be nice if we could cut down on this
 			lb := labels.NewBuilder(res)
 
 			for k, v := range ls {

--- a/promq/term/plot/axes.go
+++ b/promq/term/plot/axes.go
@@ -117,6 +117,9 @@ func EvenlySpacedTicks(graph *PlatonicGraph, outerSize ScreenSize, scale TickSca
 		if platRngInc == 0 {
 			platRngInc = graph.RangeMax // just two ticks
 		}
+		if platRngInc == 0 { // in case (graph.RangeMax - graph.RangeMin) == 0
+			platRngInc = 1
+		}
 		for x := graph.RangeMin; x <= graph.RangeMax; x += platRngInc {
 			platRngTicks = append(platRngTicks, x)
 		}


### PR DESCRIPTION
This fixes various test flakes and issues:

- resolved intermitent flake involving text not showing up due to
go-prompt consuming text after receiving a newline, but then ignoring it

- resolved intermitent crash due to "use-after-free"-type bug due to a
refactor in the query runner code

- resolved a flake caused by running assertions in a goroutine after the
test ended
